### PR TITLE
Add "@types/serviceworker" dependency and service worker

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "@types/react": "^18.2.66",
     "@types/react-dom": "^18.2.22",
+    "@types/serviceworker": "^0.0.86",
     "@typescript-eslint/eslint-plugin": "^7.2.0",
     "@typescript-eslint/parser": "^7.2.0",
     "@vitejs/plugin-react": "^4.2.1",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,6 +7,22 @@ import "./index.css";
 import { router } from "./routes.tsx";
 import { clientId, domain } from "./utils.ts";
 
+if ("serviceWorker" in navigator) {
+  window.addEventListener("load", () => {
+    navigator.serviceWorker
+      .register("/service-worker.ts")
+      .then((registration) => {
+        console.log(
+          "Service Worker registered with scope:",
+          registration.scope
+        );
+      })
+      .catch((error) => {
+        console.log("Service Worker registration failed:", error);
+      });
+  });
+}
+
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <Auth0Provider

--- a/src/serviceWorker.ts
+++ b/src/serviceWorker.ts
@@ -1,0 +1,75 @@
+// Importação dos tipos de eventos do Service Worker
+
+const CACHE_NAME = "film-cache-v1";
+const DATA_CACHE_NAME = "data-cache-v1";
+const urlsToCache = [
+  "/",
+  "/index.html",
+  "/styles.css",
+  "/script.js", 
+];
+
+// Evento de instalação
+self.addEventListener("install", (event: ExtendableEvent) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => {
+      console.log("Files cached");
+      return cache.addAll(urlsToCache);
+    })
+  );
+});
+
+// Evento de ativação
+self.addEventListener("activate", (event: ExtendableEvent) => {
+  const cacheWhitelist = [CACHE_NAME, DATA_CACHE_NAME];
+  event.waitUntil(
+    caches.keys().then((keyList) => {
+      return Promise.all(
+        keyList.map((key) => {
+          if (!cacheWhitelist.includes(key)) {
+            console.log("Removing old cache:", key);
+            return caches.delete(key);
+          }
+        })
+      );
+    })
+  );
+});
+
+// Evento de busca (fetch)
+self.addEventListener("fetch", (event: FetchEvent) => {
+  if (event.request.url.includes("/company/10342/movies")) {
+    event.respondWith(
+      caches.open(DATA_CACHE_NAME).then(async (cache) => {
+        try {
+          const response = await fetch(event.request);
+          if (response.status === 200) {
+            cache.put(event.request.url, response.clone());
+          }
+          return response;
+        } catch {
+          return (await cache.match(event.request)) ?? new Response();
+        }
+      })
+    );
+  } else if (event.request.destination === "image") {
+    event.respondWith(
+      caches.match(event.request).then((response) => {
+        return (
+          response ||
+          fetch(event.request).then(async (fetchResponse) => {
+            const cache = await caches.open(CACHE_NAME);
+            cache.put(event.request, fetchResponse.clone());
+            return fetchResponse;
+          })
+        );
+      })
+    );
+  } else {
+    event.respondWith(
+      caches.match(event.request).then((response) => {
+        return response || fetch(event.request);
+      })
+    );
+  }
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ES2020", "DOM", "DOM.Iterable","webworker"],
     "module": "ESNext",
     "skipLibCheck": true,
 
@@ -20,6 +20,6 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src"],
+  "include": ["src", "src/serviceWorker.ts"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -774,6 +774,11 @@
   resolved "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz"
   integrity sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==
 
+"@types/serviceworker@^0.0.86":
+  version "0.0.86"
+  resolved "https://registry.yarnpkg.com/@types/serviceworker/-/serviceworker-0.0.86.tgz#3a9a2f0632a81a06f9c2304cb0911b2379e004f6"
+  integrity sha512-RAi6tWm5hfipcDKX3l2GNhGseUim97RkJCnhUseNaDMfWtxcgolrHEBR5b5tYL9aT8TIhxcrqQVfF6DlnZsCPg==
+
 "@types/stylis@4.2.0":
   version "4.2.0"
   resolved "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.0.tgz"


### PR DESCRIPTION
This pull request adds the "@types/serviceworker" dependency to the project's "devDependencies" in the package.json file, enabling TypeScript support for Service Worker APIs and registers the service worker, enabling offline functionality and caching of assets. These changes enhance the user experience and make the application more reliable.